### PR TITLE
Step 9 Dependency Update

### DIFF
--- a/build-scripts/install-npsp.sh
+++ b/build-scripts/install-npsp.sh
@@ -71,7 +71,7 @@ mv "Cumulus-rel-$NPSP_CORE_VERSION/unpackaged/" cumulus && \
 cd .. && \
 echo "" && \
 
-# Workaround for post-install step 9 unless the following gets accepted - https://github.com/SalesforceFoundation/Cumulus/pull/4212
+# With Step 8 installing the npsp managed package, this updates the token with the prefix
 find temp/cumulus/post/first -type f -exec sed -i '' -e "s/%%%NAMESPACE%%%/npsp__/g" {} \;
 
 # Install dependencies

--- a/build-scripts/install-npsp.sh
+++ b/build-scripts/install-npsp.sh
@@ -105,7 +105,7 @@ sfdx force:package:install --package $NPSP_CORE_PACKAGE -w 10 --noprompt -u $ORG
 echo "" && \
 
 echo "Installing dependency 9/9: Configuration..." && \
-sfdx force:mdapi:deploy -d "temp/cumulus/config/managed" -w 10 -u $ORG_ALIAS && \
+sfdx force:mdapi:deploy -d "temp/cumulus/config/trial" -w 10 -u $ORG_ALIAS && \
 echo "" && \
 
 # Remove temp install dir

--- a/build-scripts/install-npsp.sh
+++ b/build-scripts/install-npsp.sh
@@ -71,6 +71,9 @@ mv "Cumulus-rel-$NPSP_CORE_VERSION/unpackaged/" cumulus && \
 cd .. && \
 echo "" && \
 
+# Workaround for post-install step 9 unless the following gets accepted - https://github.com/SalesforceFoundation/Cumulus/pull/4212
+find temp/cumulus/post/first -type f -exec sed -i '' -e "s/%%%NAMESPACE%%%/npsp__/g" {} \;
+
 # Install dependencies
 echo "Installing dependency 1/9: Opportunity record types..." && \
 sfdx force:mdapi:deploy -d "temp/cumulus/pre/opportunity_record_types" -w 10 -u $ORG_ALIAS && \
@@ -104,8 +107,8 @@ echo "Installing dependency 8/9: Nonprofit success pack..." && \
 sfdx force:package:install --package $NPSP_CORE_PACKAGE -w 10 --noprompt -u $ORG_ALIAS && \
 echo "" && \
 
-echo "Installing dependency 9/9: Configuration..." && \
-sfdx force:mdapi:deploy -d "temp/cumulus/config/trial" -w 10 -u $ORG_ALIAS && \
+echo "Installing dependency 9/9: Post NPSP Configuration..." && \
+sfdx force:mdapi:deploy -d "temp/cumulus/post/first" -w 10 -u $ORG_ALIAS && \
 echo "" && \
 
 # Remove temp install dir


### PR DESCRIPTION
Updated the Step 9 dependency to install the 'post' folder configuration. The managed folder when installing dependency 9/9 was removed in pull request - SalesforceFoundation/Cumulus#3900. I attempted to reference the trial folder but there's a number of metadata items needing remediation.

It has been replaced with installing the post install configuration in the unpackaged folder. Line 75 includes a workaround that applies the npsp prefix since this is installing the managed package version.